### PR TITLE
Using standard library (urllib2)

### DIFF
--- a/redpen.py
+++ b/redpen.py
@@ -1,4 +1,4 @@
-import requests
+import urllib2
 import json
 import argparse
 import sys
@@ -16,7 +16,8 @@ class RedPen:
         self.url = url
 
     def validate(self):
-        return requests.post(self.url, json=self.conf).json()
+        req = urllib2.Request(self.url, data=json.dumps(self.conf), headers={'Content-Type':'application/json'})
+        return json.loads(urllib2.urlopen(req).read())
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
Hello, I've replaced the requests library with more standard one (urllib2.)

Rationale: I think it's more easy for everyone to try it out if its dependency kept meek.

Keep up good work! 
